### PR TITLE
Enforce dark theme

### DIFF
--- a/src/app.html
+++ b/src/app.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en">
+<html lang="en" data-theme="dark">
   <head>
     <meta charset="utf-8" />
     <link rel="icon" href="%sveltekit.assets%/favicon.ico" />


### PR DESCRIPTION
Small fix to enforce dark theme - if darkness is what we embrace 🧛 
 
Noticed this issue on mobile:

Before:

<img src="https://github.com/cardano-miners/fortuna/assets/10722/afccda28-fa7c-4e4d-96dc-dd124134a43f" height="300">

After:

<img src="https://github.com/cardano-miners/fortuna/assets/10722/9224b846-389e-47ab-b72c-d4bbdc3fd45e" height="300">
